### PR TITLE
[Fix]: use provided file name

### DIFF
--- a/AudicaDownloader/Downloader.cs
+++ b/AudicaDownloader/Downloader.cs
@@ -64,8 +64,8 @@ namespace AudicaDownloader
             for (int i = 0; i < songs.Count; i++)
             {
                 AudicaSong song = songs[i];
-                Console.Write($"({i + 1}/{songs.Count}) Downloading {song.SongId}...");
-                if(File.Exists(Path.Combine(gameFolder, song.SongId + ".audica")))
+                Console.Write($"({i + 1}/{songs.Count}) Downloading {song.Filename}...");
+                if(File.Exists(Path.Combine(gameFolder, song.Filename)))
                 {
                     Console.WriteLine("Skipped (already exists)");
                     continue;
@@ -102,7 +102,7 @@ namespace AudicaDownloader
 
         public Task<DownloadResult> DownloadSong(AudicaSong song, string downloadFolder)
         {
-            string downloadPath = Path.Combine(downloadFolder, song.SongId + ".audica");
+            string downloadPath = Path.Combine(downloadFolder, song.Filename);
             return DownloadSong(song.DownloadUrl, song.SongId, downloadPath);
         }
 

--- a/AudicaDownloader/Program.cs
+++ b/AudicaDownloader/Program.cs
@@ -30,7 +30,7 @@ namespace AudicaDownloader
                 songs.AddRange(songList.Songs);
                 songCount += songList.Songs.Count;
             }
-            var songsToDownload = songs.GroupBy(s => s.SongId).Select(g => g.OrderByDescending(g => g.UploadTime).First()).ToList(); // Remove duplicate IDs, choose latest
+            var songsToDownload = songs.GroupBy(s => s.Filename).Select(g => g.OrderByDescending(g => g.UploadTime).First()).ToList(); // Remove duplicate IDs, choose latest
             Console.WriteLine($"Found {songsToDownload.Count} songs");
             var downloadResults = await downloader.DownloadSongs(songsToDownload).ConfigureAwait(false);
             var successfulDownloads = downloadResults.Where(r => r.Successful).Count();


### PR DESCRIPTION
causes issues with the sites downloads not using ID, use the provided file name to skip and issues creating multiple leaderboards